### PR TITLE
Add project src path for mkdocstrings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,4 +6,7 @@ theme:
   name: material
 
 plugins:
-- mkdocstrings
+- mkdocstrings:
+    handlers:
+      python:
+        paths: [src]


### PR DESCRIPTION
Fixes failing gh action for mkdocs

https://mkdocstrings.github.io/python/usage/#paths